### PR TITLE
use static::define() instead of self::$container

### DIFF
--- a/src/LazySubscriber.php
+++ b/src/LazySubscriber.php
@@ -35,7 +35,9 @@ abstract class LazySubscriber implements SubscriberInterface
      *
      * @return array
      */
-    abstract function define();
+    static function define() {
+        return [];
+    }
 
 
     /**
@@ -47,7 +49,7 @@ abstract class LazySubscriber implements SubscriberInterface
     {
         $events = array();
 
-        foreach (self::$container as $name => $function) {
+        foreach (static::define() as $name => $function) {
             $events['Enlight_Bootstrap_InitResource_' . $name] = 'load';
         }
 


### PR DESCRIPTION
when iterating over self::$container, it was an empty array,
which lead to no events returned in getSubscribedEvents()

As the events are defined in define(), we can simply use the array
returned from there.

To do this, define() needs to be static, too.

As some PHP Versions disallow abstract static methods,
change it to a non-static version and add a sane default
implementation.
